### PR TITLE
Remove duplicate products from related categories

### DIFF
--- a/server/database/seed.js
+++ b/server/database/seed.js
@@ -2,7 +2,6 @@ const faker = require('faker');
 const models = require('../models');
 
 async function seedDatabase() {
-
   // Generate categories
   const cats = new Set();
   while (cats.size < 10) {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -3,11 +3,10 @@ const db = require('../database');
 module.exports = {
   products: {
     getRelated(productId, callback) {
-      const sql = 'SELECT p.*, c.name AS category_name FROM products AS p INNER JOIN productCategories AS pcj ON pcj.id_products = p.id INNER JOIN categories AS c ON pcj.id_categories = c.id WHERE pcj.id_categories IN (SELECT pcj.id_categories FROM productCategories AS pcj INNER JOIN products AS p ON p.id = pcj.id_products WHERE p.productId = ?) ORDER BY avgRating DESC, numReviews DESC LIMIT 20';
+      const sql = 'SELECT DISTINCT p.* FROM products AS p LEFT OUTER JOIN productCategories AS pcj ON pcj.id_products = p.id WHERE pcj.id_categories IN (SELECT pcj.id_categories FROM productCategories AS pcj INNER JOIN products AS p ON p.id = pcj.id_products WHERE p.productId = ?) ORDER BY avgRating DESC, numReviews DESC LIMIT 20';
       db.query(sql, productId, (err, results) => {
         callback(err, results);
       });
-
     },
     addNew(params, callback = () => {}) {
       const sql = 'INSERT INTO products (productId, name, price, prime, imageUrl, numReviews, avgRating) VALUES (?, ?, ?, ?, ?, ?, ?)';


### PR DESCRIPTION
@asmit222 please review.

This is a minor change to address the following bug in my mysql query 
for related products.

If a product belonged to more than one of the same categories as the
currently displayed product, it would add the related product for each
category that it had in common with the current product. This patch
fixes that so each unique product is only showed once.